### PR TITLE
feat(database): Cria migrations para as tabelas de organização interna

### DIFF
--- a/database/migrations/2025_10_15_143656_create_ou_table.php
+++ b/database/migrations/2025_10_15_143656_create_ou_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('ou', function (Blueprint $table) {
+            $table->id();
+            $table->string('nome');
+            $table->string('sigla');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('ou');
+    }
+};

--- a/database/migrations/2025_10_15_143818_create_grupo_table.php
+++ b/database/migrations/2025_10_15_143818_create_grupo_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('grupo', function (Blueprint $table) {
+            $table->id();
+            $table->string('nome');
+            $table->integer('ou_id');
+            $table->foreign('ou_id')
+                  ->references('id')
+                  ->on('ou')
+                  ->onDelete('cascade');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('grupo');
+    }
+};

--- a/database/migrations/2025_10_15_144145_create_usuario_grupo_table.php
+++ b/database/migrations/2025_10_15_144145_create_usuario_grupo_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('usuario_grupo', function (Blueprint $table) {
+            $table->integer('usuario_id');
+            $table->foreign('usuario_id')
+                  ->references('id')
+                  ->on('users')
+                  ->onDelete('cascade');
+            $table->integer('grupo_id');
+            $table->foreign('grupo_id')
+                  ->references('id')
+                  ->on('grupo')
+                  ->onDelete('cascade');
+            $table->primary(['usuario_id','grupo_id']);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('usuario_grupo');
+    }
+};


### PR DESCRIPTION
Cria as migrations para as seguintes tabelas:
- ou (unidades organizacionais)
- grupo
- usuario_grupo (tabela pivot)

Essas tabelas são usadas para organizar os usuários em grupos e unidades organizacionais, permitindo um controle de acesso mais granular.

Closes #18