### PR TITLE
chore(database): Adiciona coluna codigo_pessoa à tabela users

### DIFF
--- a/database/factories/VinculoFactory.php
+++ b/database/factories/VinculoFactory.php
@@ -21,7 +21,7 @@ class VinculoFactory extends Factory
             // Garante que o vínculo sempre terá uma pessoa válida associada.
             'codigo_pessoa' => Pessoa::factory(),
             // Gera uma palavra aleatória para o tipo de vínculo.
-            'tipo_vinculo' => $this->faker->word(),
+            'tipo_vinculo' => this->faker->randomElement(['DOCENTE', 'ALUNOPOS', 'SERVIDOR']),
         ];
     }
 }

--- a/database/migrations/2025_10_16_164946_add_codigo_pessoa_to_users_table.php
+++ b/database/migrations/2025_10_16_164946_add_codigo_pessoa_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->integer('codigo_pessoa')->unique()->nullable()->after('email');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('codigo_pessoa');
+        });
+    }
+};


### PR DESCRIPTION
## Summary
Este PR atende à necessidade de vincular um usuário do sistema a uma pessoa, adicionando a coluna `codigo_pessoa` à tabela `users`.

## Changes Made
- Cria uma migration para adicionar a coluna `codigo_pessoa` (int, único, nullable) à tabela `users`.
- Atualiza a `VinculoFactory` para gerar dados mais realistas.

## Related Issues
Closes #22