### PR TITLE
docs: corrige link do repositório no README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ O sistema já está em produção com as seguintes capacidades:
 
 1.  **Clonar o repositório:**
     ```bash
-    git clone https://github.com/ime-usp-br/CotaG.git
-    cd CotaG
+    git clone https://github.com/ime-usp-br/CotaG_L12.git
+    cd CotaG_L12
     ```
 
 2.  **Configurar o ambiente:**


### PR DESCRIPTION
## Descrição
Corrige a URL do repositório no arquivo README.md. O link estava apontando para CotaG, mas o correto é CotaG_L12.

## Mudanças
- Atualização do link de CotaG para CotaG_L12.